### PR TITLE
Update zlib_bootstrap-1.2.11.recipe

### DIFF
--- a/sys-libs/zlib_bootstrap/zlib_bootstrap-1.2.11.recipe
+++ b/sys-libs/zlib_bootstrap/zlib_bootstrap-1.2.11.recipe
@@ -18,6 +18,7 @@ REQUIRES="
 	haiku$secondaryArchSuffix
 	"
 BUILD_REQUIRES="
+	gcc${secondaryArchSuffix}_syslibs
 	"
 BUILD_PREREQUIRES="
 	haiku_devel
@@ -55,7 +56,8 @@ BUILD()
 		SET(CMAKE_SYSTEM_VERSION 1)
 		SET(CMAKE_C_COMPILER $effectiveTargetMachineTriple-gcc)
 		SET(CMAKE_CXX_COMPILER $effectiveTargetMachineTriple-g++)
-		SET(CMAKE_FIND_ROOT_PATH $crossSysrootDir)
+                SET(CMAKE_SYSROOT $crossSysrootDir)
+                SET(CMAKE_BUILD_RPATH /boot/system/lib)
 		SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 		SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 		SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)


### PR DESCRIPTION
Make zlib compile for ARM64, not sure why ARM64 is special. 
libroot.so needs to find libgcc_s.so.1 and its link for unwind symbols. 
CMAKE_SYSROOT is a nice way to set our sysroot.
CMAKE_BUILD_RPATH is the relative path for the link.