### PR TITLE
python: add arm to 3.9.1

### DIFF
--- a/dev-lang/python_bootstrap/python_bootstrap-3.9.1.recipe
+++ b/dev-lang/python_bootstrap/python_bootstrap-3.9.1.recipe
@@ -22,7 +22,7 @@ if [ "$secondaryArchSuffix" = _x86 ] ; then
 	"
 fi
 
-ARCHITECTURES=" !x86_gcc2 ?x86 ?x86_64 ?arm arm64 ?riscv64"
+ARCHITECTURES=" !x86_gcc2 ?x86 ?x86_64 arm arm64 ?riscv64"
 
 GLOBAL_WRITABLE_FILES="
 	non-packaged/lib/python3.9/site-packages directory keep-old


### PR DESCRIPTION
Depends on libffi.
Bootstrap build looks OK once libffi_boostrap is enabled.