### PR TITLE
make: fix build after the dirent refactor

### DIFF
--- a/sys-devel/make_bootstrap/patches/make-4.3.patchset
+++ b/sys-devel/make_bootstrap/patches/make-4.3.patchset
@@ -1,4 +1,4 @@
-From aa0681736940d18a5eb4a7bfad3b70f77159ef83 Mon Sep 17 00:00:00 2001
+From f41f5ce2f53d1094f9070e428b0d58a679a1b178 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Fri, 26 Feb 2016 14:51:15 +0000
 Subject: Haiku patch
@@ -18,5 +18,28 @@ index 3ce21db..45bbe0f 100644
  # else
     /* These platforms don't have <ar.h> but have archives in the same format
 -- 
-2.28.0
+2.30.2
+
+
+From e38f464cbf874ee7fc19a77d7f00bd29600bd31f Mon Sep 17 00:00:00 2001
+From: David Karoly <david.karoly@outlook.com>
+Date: Sun, 21 Nov 2021 15:47:19 +0000
+Subject: fix build
+
+
+diff --git a/src/dir.c b/src/dir.c
+index 862a18e..620ca26 100644
+--- a/src/dir.c
++++ b/src/dir.c
+@@ -1226,7 +1226,7 @@ read_dirstream (__ptr_t stream)
+           /* The glob interface wants a 'struct dirent', so mock one up.  */
+           struct dirent *d;
+           size_t len = df->length + 1;
+-          size_t sz = sizeof (*d) - sizeof (d->d_name) + len;
++          size_t sz = offsetof (struct dirent, d_name) + len;
+           if (sz > bufsz)
+             {
+               bufsz *= 2;
+-- 
+2.30.2
 


### PR DESCRIPTION
similar to the one in regular (non-cross) haikuports