### PR TITLE
ncurses6: add new recipe for version 6.2

### DIFF
--- a/sys-libs/ncurses_bootstrap/ncurses6_bootstrap-6.2.recipe
+++ b/sys-libs/ncurses_bootstrap/ncurses6_bootstrap-6.2.recipe
@@ -1,0 +1,220 @@
+SUMMARY="New curses library"
+DESCRIPTION="The Ncurses (new curses) library is a free software emulation of \
+curses in System V Release 4.0, and more. It uses Terminfo format, supports \
+pads and color and multiple highlights and forms characters and function-key \
+mapping, and has all the other SYSV-curses enhancements over BSD Curses.
+The ncurses code was developed under GNU/Linux. It has been in use for some \
+time with OpenBSD as the system curses library, and on FreeBSD and NetBSD as \
+an external package. It should port easily to any ANSI/POSIX-conforming UNIX. \
+It has even been ported to OS/2 Warp!
+The distribution includes the library and support utilities, including a \
+terminfo compiler tic, a decompiler infocmp, clear, tput, tset, and a \
+termcap conversion tool captoinfo. Full manual pages are provided for the \
+library and tools."
+HOMEPAGE="https://www.gnu.org/software/ncurses/ncurses.html"
+COPYRIGHT="1998-2018 Free Software Foundation, Inc."
+LICENSE="MIT"
+REVISION="1"
+SOURCE_URI="https://ftpmirror.gnu.org/ncurses/ncurses-$portVersion.tar.gz
+	https://ftp.gnu.org/gnu/ncurses/ncurses-$portVersion.tar.gz"
+CHECKSUM_SHA256="30306e0c76e0f9f1f0de987cf1c82a5c21e1ce6568b9227f7da5b71cbea86c9d"
+SOURCE_DIR="ncurses-$portVersion"
+PATCHES="ncurses-$portVersion.patchset"
+
+ARCHITECTURES="?x86_gcc2 ?x86 ?x86_64 ?ppc arm ?arm64 ?riscv64 ?sparc ?m68k"
+SECONDARY_ARCHITECTURES="?x86_gcc2 ?x86"
+
+libVersion="6.2.0"
+libVersionCompat="$libVersion compat >= 6"
+portVersionCompat="$portVersion compat >= 6"
+
+PROVIDES="
+	ncurses6_bootstrap$secondaryArchSuffix = $portVersionCompat
+	ncurses6$secondaryArchSuffix = $portVersionCompat
+	lib:libform$secondaryArchSuffix = $libVersionCompat
+	lib:libformw$secondaryArchSuffix = $libVersionCompat
+	lib:libmenu$secondaryArchSuffix = $libVersionCompat
+	lib:libmenuw$secondaryArchSuffix = $libVersionCompat
+	lib:libncurses$secondaryArchSuffix = $libVersionCompat
+	lib:libncursesw$secondaryArchSuffix = $libVersionCompat
+	lib:libncurses++$secondaryArchSuffix = $libVersionCompat
+	lib:libncurses++w$secondaryArchSuffix = $libVersionCompat
+	lib:libpanel$secondaryArchSuffix = $libVersionCompat
+	lib:libpanelw$secondaryArchSuffix = $libVersionCompat
+	"
+if [ -z "$secondaryArchSuffix" ]; then
+	PROVIDES="$PROVIDES
+		cmd:captoinfo = $portVersionCompat
+		cmd:clear = $portVersionCompat
+		cmd:infocmp = $portVersionCompat
+		cmd:infotocap = $portVersionCompat
+		cmd:reset = $portVersionCompat
+		cmd:tabs = $portVersionCompat
+		cmd:tic = $portVersionCompat
+		cmd:toe = $portVersionCompat
+		cmd:tput = $portVersionCompat
+		cmd:tset = $portVersionCompat
+		"
+fi
+
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+if [ -n "$secondaryArchSuffix" ]; then
+	REQUIRES="$REQUIRES
+		ncurses6_bootstrap == $portVersionCompat base
+		"
+fi
+PROVIDES_devel="
+	ncurses6_bootstrap${secondaryArchSuffix}_devel = $portVersionCompat
+	ncurses6${secondaryArchSuffix}_devel = $portVersionCompat
+	cmd:ncurses6_config$secondaryArchSuffix = $portVersionCompat
+	cmd:ncursesw6_config$secondaryArchSuffix = $portVersionCompat
+	devel:libform$secondaryArchSuffix = $libVersionCompat
+	devel:libformw$secondaryArchSuffix = $libVersionCompat
+	devel:libmenu$secondaryArchSuffix = $libVersionCompat
+	devel:libmenuw$secondaryArchSuffix = $libVersionCompat
+	devel:libncurses$secondaryArchSuffix = $libVersionCompat
+	devel:libncursesw$secondaryArchSuffix = $libVersionCompat
+	devel:libncurses++$secondaryArchSuffix = $libVersionCompat
+	devel:libncurses++w$secondaryArchSuffix = $libVersionCompat
+	devel:libpanel$secondaryArchSuffix = $libVersionCompat
+	devel:libpanelw$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	ncurses6_bootstrap$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	gcc${secondaryArchSuffix}_syslibs_devel
+	"
+BUILD_PREREQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	cmd:${effectiveTargetMachineTripleAsName}_libtool
+	cmd:${effectiveTargetMachineTripleAsName}_libtoolize
+	cmd:gcc
+	cmd:grep
+	cmd:ld
+	cmd:make
+	cmd:sed
+	"
+
+PATCH()
+{
+	if [ "$effectiveTargetArchitecture" = x86_gcc2 ]; then
+		sed -i 's/=stdc++/=stdc++.r4/' aclocal.m4 configure
+	fi
+}
+
+doBuild()
+{
+	if [ $# -lt 1 ]; then
+		echo >&2 "Usage: doBuild <targetDir> [ <configureFlags> ... ]"
+		exit 1
+	fi
+
+	targetDir=$(pwd)/$1
+	shift 1
+
+	# Parse additional arguments. "--libs-only" means we only want the
+	# libraries, nothing else. "--without-progs" means no programs and no
+	# terminfo DB (requires tic).
+	local noData
+	local libsOnly
+	local configureArgs
+	local arg
+	for arg in $@; do
+		case "$arg" in
+			--libs-only)
+				noData=1
+				libsOnly=1
+				arg="--without-progs"
+				;;
+			--without-progs)
+				noData=1
+				;;
+		esac
+		configureArgs="$configureArgs $arg"
+	done
+
+	rm -rf $targetDir
+	mkdir $targetDir
+
+	libtool=$(which ${effectiveTargetMachineTriple}-libtool)
+
+	runConfigure \
+		--omit-dirs "dataRootDir docDir" ./configure \
+		--build=$buildMachineTriple --host=$effectiveTargetMachineTriple \
+		--with-libtool=$libtool \
+		--disable-stripping \
+		--enable-termcap \
+		--enable-hard-tabs \
+		--enable-pc-files \
+		$configureArgs
+	make $jobArgs
+
+	if [ -z "$noData" ]; then
+		# We need LIBRARY_PATH to include the library installation directory,
+		# since the installation process for the terminfo database will run tic
+		# and the built-in rpath doesn't consider the DESTDIR we're using.
+		LIBRARY_PATH="$targetDir/$prefix/lib:$LIBRARY_PATH" \
+		make install DESTDIR=$targetDir
+	else
+		make install.libs DESTDIR=$targetDir
+		if [ -z "$libsOnly" ]; then
+			make install.includes DESTDIR=$targetDir
+			make install.man DESTDIR=$targetDir
+		fi
+	fi
+
+	# clean up for the next build
+	make clean
+}
+
+BUILD()
+{
+	# Unfortunately building only works in the source directory. So we build
+	# two times -- once without and once with wide-char support -- installing in
+	# temporary directories from which we copy to the actual installation
+	# directory in INSTALL().
+
+	# For the secondary architecture we don't want the programs nor the
+	# terminfo DB. The main package will depend on the primary package which
+	# provides all this.
+	local withoutProgramArgs
+	if [ -n "$secondaryArchSuffix" ]; then
+		withoutProgramArgs="--without-progs"
+	fi
+
+	doBuild build-nowidec $withoutProgramArgs
+	doBuild build-widec --enable-widec --libs-only
+}
+
+INSTALL()
+{
+	cp -ra build-nowidec/$prefix/. $installDestDir$prefix
+	cp -ra build-widec/$prefix/. $installDestDir$prefix
+
+	# prepare develop/lib
+	prepareInstalledDevelLibs \
+		libform libmenu libncurses libncurses++ libpanel \
+		libformw libmenuw libncursesw libncurses++w libpanelw
+
+	# fix ncurses[w]6-config
+	fixDevelopLibDirReferences $installDestDir$binDir/ncurses6-config \
+		$installDestDir$binDir/ncursesw6-config
+
+	# devel package
+	packageEntries devel \
+		$installDestDir$binDir/ncurses6-config \
+		$installDestDir$binDir/ncursesw6-config \
+		$installDestDir$developDir \
+		$installDestDir$manDir/man3
+
+	# For the secondary architecture package clean up stuff we don't need, since
+	# we make it depend on the primary architecture package.
+	if [ -n "$secondaryArchSuffix" ]; then
+		rm -rf $installDestDir$binDir
+		rm -rf $installDestDir$documentationDir
+	fi
+}

--- a/sys-libs/ncurses_bootstrap/patches/ncurses-6.2.patchset
+++ b/sys-libs/ncurses_bootstrap/patches/ncurses-6.2.patchset
@@ -1,0 +1,42 @@
+From c10c7316b0be6ee2249ee2eeeeea6bbeb973d4cd Mon Sep 17 00:00:00 2001
+From: Ingo Weinhold <ingo_weinhold@gmx.de>
+Date: Mon, 8 Jul 2013 15:51:09 +0200
+Subject: progs/Makefile.in: make sure the right programs are installed
+
+The Makefile installed the libtool wrapper scripts which are only meant
+to be used for the build.
+
+diff --git a/progs/Makefile.in b/progs/Makefile.in
+index bdb8a0f..f3170f1 100644
+--- a/progs/Makefile.in
++++ b/progs/Makefile.in
+@@ -188,19 +188,19 @@ transform.h :
+ 	echo "#endif /* __TRANSFORM_H */"				>>$@
+ 
+ install.progs: $(AUTO_SRC) $(PROGS) $(DESTDIR)$(bindir)
+-@MAKE_TERMINFO@	$(LIBTOOL_INSTALL) $(INSTALL_PROG) tic$x     $(DESTDIR)$(bindir)/$(actual_tic)
+-@MAKE_TERMINFO@	$(LIBTOOL_INSTALL) $(INSTALL_PROG) toe$x     $(DESTDIR)$(bindir)/$(actual_toe)
++@MAKE_TERMINFO@	$(LIBTOOL_INSTALL) $(INSTALL_PROG) .libs/tic$x     $(DESTDIR)$(bindir)/$(actual_tic)
++@MAKE_TERMINFO@	$(LIBTOOL_INSTALL) $(INSTALL_PROG) .libs/toe$x     $(DESTDIR)$(bindir)/$(actual_toe)
+ @MAKE_TERMINFO@	@echo "linking $(actual_infotocap) to $(actual_tic)"
+ @MAKE_TERMINFO@	-@rm -f $(DESTDIR)$(bindir)/$(actual_infotocap)
+ @MAKE_TERMINFO@	(cd $(DESTDIR)$(bindir) && $(LN_S) $(actual_tic) $(actual_infotocap))
+ @MAKE_TERMINFO@	@echo "linking $(actual_captoinfo) to $(actual_tic)"
+ @MAKE_TERMINFO@	-@rm -f $(DESTDIR)$(bindir)/$(actual_captoinfo)
+ @MAKE_TERMINFO@	(cd $(DESTDIR)$(bindir) && $(LN_S) $(actual_tic) $(actual_captoinfo))
+-	$(LIBTOOL_INSTALL) $(INSTALL_PROG) infocmp$x $(DESTDIR)$(bindir)/$(actual_infocmp)
+-	$(LIBTOOL_INSTALL) $(INSTALL_PROG) clear$x   $(DESTDIR)$(bindir)/$(actual_clear)
+-	$(LIBTOOL_INSTALL) $(INSTALL_PROG) tabs$x    $(DESTDIR)$(bindir)/$(actual_tabs)
+-	$(LIBTOOL_INSTALL) $(INSTALL_PROG) tput$x    $(DESTDIR)$(bindir)/$(actual_tput)
+-	$(LIBTOOL_INSTALL) $(INSTALL_PROG) tset$x    $(DESTDIR)$(bindir)/$(actual_tset)
++	$(LIBTOOL_INSTALL) $(INSTALL_PROG) .libs/infocmp$x $(DESTDIR)$(bindir)/$(actual_infocmp)
++	$(LIBTOOL_INSTALL) $(INSTALL_PROG) .libs/clear$x   $(DESTDIR)$(bindir)/$(actual_clear)
++	$(LIBTOOL_INSTALL) $(INSTALL_PROG) .libs/tabs$x    $(DESTDIR)$(bindir)/$(actual_tabs)
++	$(LIBTOOL_INSTALL) $(INSTALL_PROG) .libs/tput$x    $(DESTDIR)$(bindir)/$(actual_tput)
++	$(LIBTOOL_INSTALL) $(INSTALL_PROG) .libs/tset$x    $(DESTDIR)$(bindir)/$(actual_tset)
+ 	@echo "linking $(actual_reset) to $(actual_tset)"
+ 	-@rm -f $(DESTDIR)$(bindir)/$(actual_reset)
+ 	(cd $(DESTDIR)$(bindir) && $(LN_S) $(actual_tset) $(actual_reset))
+-- 
+1.7.10.2
+


### PR DESCRIPTION
ncurses-6.0 won't compile on gcc11 any more. Therefore adding new recipe for ncurse-6.2.
