### PR TITLE
python_bootstrap: enable parallel build

### DIFF
--- a/dev-lang/python_bootstrap/python_bootstrap-3.9.1.recipe
+++ b/dev-lang/python_bootstrap/python_bootstrap-3.9.1.recipe
@@ -96,8 +96,7 @@ BUILD()
 		ac_cv_file__dev_ptmx=yes \
 		ac_cv_file__dev_ptc=no \
 		ac_cv_buggy_getaddrinfo=no
-	make
-
+	make $jobArgs
 }
 
 INSTALL()


### PR DESCRIPTION
This one is optional.
It seems that we can enable parallel build for python-3.9.1.
This way the bootstrap finishes a bit earlier.