### PR TITLE
freetype: fix download url, disable static lib

### DIFF
--- a/media-libs/freetype_bootstrap/freetype_bootstrap-2.6.3.recipe
+++ b/media-libs/freetype_bootstrap/freetype_bootstrap-2.6.3.recipe
@@ -5,7 +5,7 @@ output (glyph images) of most vector and bitmap font formats."
 HOMEPAGE="http://www.freetype.org"
 LICENSE="FreeType"
 COPYRIGHT="1996-2013 David Turner, Robert Wilhelm, Werner Lemberg, et al."
-SOURCE_URI="http://download.savannah.gnu.org/releases/freetype/freetype-$portVersion.tar.bz2"
+SOURCE_URI="https://download.savannah.gnu.org/releases/freetype/freetype-old/freetype-$portVersion.tar.bz2"
 CHECKSUM_SHA256="371e707aa522acf5b15ce93f11183c725b8ed1ee8546d7b3af549863045863a2"
 REVISION="1"
 ARCHITECTURES="x86_gcc2 x86 x86_64 ppc arm arm64 riscv64 sparc m68k"
@@ -41,7 +41,8 @@ BUILD()
 	./autogen.sh
 	runConfigure ./configure \
 		--build=$buildMachineTriple --host=$effectiveTargetMachineTriple \
-		--with-harfbuzz=no  --with-png=no --with-zlib=no --with-bzip2=no
+		--with-harfbuzz=no  --with-png=no --with-zlib=no --with-bzip2=no \
+		--disable-static
 	make $jobArgs
 }
 


### PR DESCRIPTION
freetype-2.6.3 is now located in an archive folder on the download site so let's adjust the url