### PR TITLE
run bootstrap jam without parallelism

### DIFF
--- a/.github/workflows/bootstrap.yaml
+++ b/.github/workflows/bootstrap.yaml
@@ -75,7 +75,7 @@ jobs:
 
     - name: jam @bootstrap-raw for ${{ matrix.target }}
       working-directory: build
-      run: jam -j$(nproc) -q @bootstrap-raw
+      run: jam -q @bootstrap-raw
 
     - name: save build files in cache (${{ steps.cache-key.outputs.key }})
       uses: actions/cache/save@v3


### PR DESCRIPTION
we might get more stable bootstrap builds by disabling parallel jam execution (at least this is what I see when building locally on my laptop)