### PR TITLE
Add bootstrap recipe for libffi 3.4.4 with (temporary) patch

### DIFF
--- a/dev-libs/libffi_bootstrap/libffi_bootstrap-3.4.4.recipe
+++ b/dev-libs/libffi_bootstrap/libffi_bootstrap-3.4.4.recipe
@@ -1,0 +1,59 @@
+SUMMARY="A portable, high level programming interface"
+DESCRIPTION="Libffi is a foreign function interface library which gives its \
+user a C programming language interface used to call natively compiled \
+functions. Libffi is typically used as a bridging technology between compiled \
+and interpreted language implementations. It can also be used to implement \
+plugins."
+HOMEPAGE="http://sourceware.org/libffi"
+COPYRIGHT="1996-2022 Anthony Green, Red Hat, Inc and others."
+LICENSE="MIT"
+REVISION="1"
+SOURCE_URI="https://github.com/libffi/libffi/releases/download/v$portVersion/libffi-$portVersion.tar.gz"
+CHECKSUM_SHA256="d66c56ad259a82cf2a9dfc408b32bf5da52371500b84745f7fb8b645712df676"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="?x86"
+
+PATCHES="libffi_bootstrap-$portVersion.patchset"
+
+PROVIDES="
+	libffi_bootstrap$secondaryArchSuffix = $portVersion compat >= 3
+	libffi$secondaryArchSuffix = $portVersion compat >= 3
+	lib:libffi$secondaryArchSuffix = $portVersion compat >= 3
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	libffi_bootstrap${secondaryArchSuffix}_devel = $portVersion compat >= 3
+	devel:libffi$secondaryArchSuffix = $portVersion compat >= 3
+	"
+
+BUILD_REQUIRES="
+	"
+
+BUILD_PREREQUIRES="
+	haiku${secondaryArchSuffix}_devel
+        gcc_cross_$targetArchitecture
+        binutils_cross_$targetArchitecture
+	cmd:awk
+	cmd:make
+	"
+
+SOURCE_DIR="libffi-$portVersion"
+
+BUILD()
+{
+	runConfigure ./configure --disable-docs --build=$buildMachineTriple --host=$targetMachineTriple --disable-static
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make DESTDIR=$installDestDir install
+	prepareInstalledDevelLibs libffi
+	fixPkgconfig
+	packageEntries devel \
+		$installDestDir$developDir
+}

--- a/dev-libs/libffi_bootstrap/patches/libffi_bootstrap-3.4.4.patchset
+++ b/dev-libs/libffi_bootstrap/patches/libffi_bootstrap-3.4.4.patchset
@@ -1,0 +1,19 @@
+From: Yn0ga <ynoga@protonmail.com>
+Date: Sat, 07 October 2023 22:48:10 +0200
+Subject: Add PowerPC-haiku support in configure.host file
+
+diff --git a/configure.host b/configure.host
+index b291bd0..4cc69be 100644
+--- a/configure.host
++++ b/configure.host
+@@ -205,7 +205,7 @@ case "${host}" in
+   powerpc-*-eabi*)
+        TARGET=POWERPC; TARGETDIR=powerpc
+        ;;
+-  powerpc-*-beos*)
++  powerpc-*-beos* | powerpc-*-haiku*)
+        TARGET=POWERPC; TARGETDIR=powerpc
+        ;;
+   powerpc-*-darwin* | powerpc64-*-darwin*)
+--
+1.7.5


### PR DESCRIPTION
Libffi 3.4.4 includes several fixes over 3.3, and specifically one preventing powerpc build (https://github.com/libffi/libffi/commit/4f9e20ac51ce13d46fed3c869e1deb6d9bb89444) 
The patch is to let configure.host knows about us and will be removed for the next libffi version (if this pullrequest https://github.com/libffi/libffi/pull/799 is accepted by upstream)  