### PR TITLE
grep-2.14: Fix broken link

### DIFF
--- a/sys-apps/grep_bootstrap/grep_bootstrap-2.14.recipe
+++ b/sys-apps/grep_bootstrap/grep_bootstrap-2.14.recipe
@@ -3,8 +3,8 @@ DESCRIPTION="The grep command searches one or more input files for lines contain
 HOMEPAGE="http://www.gnu.org/software/grep/"
 LICENSE="GNU GPL v3"
 COPYRIGHT="1992-2012 Free Software Foundation, Inc."
-SOURCE_URI="http://ports-space.haiku-files.org/source/grep-2.14.tar.bz2"
-CHECKSUM_SHA256="0aa728dbb92eeec776f9551fcee1931717984a91cfd8c3df3dfb40709243ae6f"
+SOURCE_URI="https://ftp.gnu.org/gnu/grep/grep-2.14.tar.xz"
+CHECKSUM_SHA256="e70e801d4fbb16e761654a58ae48bf5020621c95c8e35bd864742577685872e1"
 REVISION="1"
 ARCHITECTURES="x86_gcc2 x86 x86_64 ppc arm arm64 riscv64 sparc m68k"
 


### PR DESCRIPTION
Replace link from a dead http://ports-space.haiku-files.org server to the official tarball.