### PR TITLE
m4_bootstrap: add version 1.4.19

### DIFF
--- a/sys-devel/m4_bootstrap/m4_bootstrap-1.4.19.recipe
+++ b/sys-devel/m4_bootstrap/m4_bootstrap-1.4.19.recipe
@@ -17,14 +17,12 @@ DESCRIPTION="
 	One of the biggest users of M4 is the GNU Autoconf project.
 	"
 HOMEPAGE="http://www.gnu.org/software/m4/"
-SOURCE_URI="http://ftp.gnu.org/gnu/m4/m4-1.4.16.tar.gz"
+SOURCE_URI="http://ftp.gnu.org/gnu/m4/m4-1.4.19.tar.gz"
 LICENSE="GNU GPL v3"
 COPYRIGHT="2000, 2005-2011 Free Software Foundation, Inc."
-CHECKSUM_SHA256="e9176a35bb13a1b08482359aa554ee8072794f58f00e4827bf0e06b570c827da"
+CHECKSUM_SHA256="3be4a26d825ffdfda52a56fc43246456989a3630093cced3fbddf4771ee58a70"
 REVISION="1"
-ARCHITECTURES="x86_gcc2 x86 x86_64 !ppc arm arm64 riscv64 sparc m68k"
-
-PATCHES="m4_bootstrap-1.4.16.patchset"
+ARCHITECTURES="x86_gcc2 x86 x86_64 ppc arm arm64 riscv64 sparc m68k"
 
 PROVIDES="
 	m4_bootstrap = $portVersion compat >= 1.4


### PR DESCRIPTION
1.4.16 did not build anymore on bootstrap builds, failing on freadahead.c.
1.4.19 does apparently build just fine, though I have only tested this for powerpc.