### PR TITLE
less_bootstrap: Add ppc to architectures

### DIFF
--- a/sys-apps/less_bootstrap/less_bootstrap-451.recipe
+++ b/sys-apps/less_bootstrap/less_bootstrap-451.recipe
@@ -12,7 +12,7 @@ CHECKSUM_SHA256="9fe8287c647afeafb4149c5dedaeacfd20971ed7c26c7553794bb750536b5f5
 LICENSE="GNU GPL v3"
 COPYRIGHT="1984-2012 Mark Nudelman"
 REVISION="1"
-ARCHITECTURES="x86_gcc2 x86 x86_64 arm arm64 riscv64 sparc m68k"
+ARCHITECTURES="x86_gcc2 x86 x86_64 ppc arm arm64 riscv64 sparc m68k"
 
 PROVIDES="
 	less_bootstrap = $portVersion


### PR DESCRIPTION
This was preventing me from bootstrapping in PPC